### PR TITLE
Add JUnit Test for Delete Command Parser and Tweak ParseDeleteCommand

### DIFF
--- a/src/main/java/seedu/command/DeleteContactCommand.java
+++ b/src/main/java/seedu/command/DeleteContactCommand.java
@@ -1,7 +1,9 @@
 package seedu.command;
 
 import seedu.contact.Contact;
+import seedu.parser.FailedCommandType;
 import seedu.ui.TextUi;
+import seedu.command.FailedCommand;
 
 public class DeleteContactCommand extends Command {
     private final int deletedIndex;
@@ -19,8 +21,8 @@ public class DeleteContactCommand extends Command {
             Contact deletedContact = contactList.getContactAtIndex(deletedIndex);
             this.contactList.deleteContact(deletedIndex);
             TextUi.deleteContactMessage(deletedContact.getName(), contactList.getListSize());
-        } catch (IndexOutOfBoundsException | NullPointerException e) {
-            TextUi.numOutOfRangeMessage(contactList.getListSize() - 1);
+        } catch (IndexOutOfBoundsException e) {
+            TextUi.numOutOfRangeMessage(contactList.getListSize());
         }
     }
 }

--- a/src/main/java/seedu/command/ViewCommand.java
+++ b/src/main/java/seedu/command/ViewCommand.java
@@ -18,8 +18,8 @@ public class ViewCommand extends Command {
         try {
             Contact viewingContact = contactList.getContactAtIndex(index);
             TextUi.viewContactMessage(viewingContact, index);
-        } catch (IndexOutOfBoundsException | NullPointerException e) {
-            TextUi.numOutOfRangeMessage(contactList.getListSize() - 1);
+        } catch (IndexOutOfBoundsException e) {
+            TextUi.numOutOfRangeMessage(contactList.getListSize());
         }
     }
 }

--- a/src/main/java/seedu/parser/MainParser.java
+++ b/src/main/java/seedu/parser/MainParser.java
@@ -109,29 +109,24 @@ public class MainParser {
         if (destructuredInputs.length == 1) {
             return new FailedCommand(FailedCommandType.MISSING_ARG);
         }
-        if (destructuredInputs.length > 2) {
-            return new FailedCommand(FailedCommandType.INVALID_FORMAT);
-        }
         try {
-            return new ViewCommand(Integer.parseInt(destructuredInputs[1]));
+            return new ViewCommand(Integer.parseInt(destructuredInputs[1].trim()));
         } catch (NumberFormatException e) {
-            return new FailedCommand(FailedCommandType.INVALID_NUM);
+            return new FailedCommand(FailedCommandType.INVALID_INDEX);
         }
     }
 
     private Command parseDeleteContact(String userInput) {
-        String[] destructuredInputs = userInput.split(" ");
+        String[] destructuredInputs = userInput.split(" ", ISOLATE_COMD_WORD);
+        //check if there is only the command word and no arguments in input
         if (destructuredInputs.length == 1) {
             return new FailedCommand(FailedCommandType.MISSING_ARG);
         }
-        if (destructuredInputs.length > 2) {
-            return new FailedCommand(FailedCommandType.INVALID_FORMAT);
-        }
         try {
-            int deletedIndex = Integer.parseInt(destructuredInputs[1]);
+            int deletedIndex = Integer.parseInt(destructuredInputs[1].trim());
             return new DeleteContactCommand(deletedIndex);
         } catch (NumberFormatException e) {
-            return new FailedCommand(FailedCommandType.INVALID_NUM);
+            return new FailedCommand(FailedCommandType.INVALID_INDEX);
         }
     }
 }

--- a/src/main/java/seedu/ui/TextUi.java
+++ b/src/main/java/seedu/ui/TextUi.java
@@ -142,12 +142,15 @@ public class TextUi {
 
     public static void numOutOfRangeMessage(int listSize) {
         String message;
+        int maxIndex = listSize - 1;
         if (listSize == 0) {
+            message = "There are no contacts stored in ConTech.";
+        } else if (listSize == 1) {
             message = "The number you have input is out of range.\n"
-                    + "Please input 0 as you only have 1 contact saved.";
+                    + "You only have 1 contact stored.";
         } else {
             message = "The number you have input is out of range.\n"
-                    + "Please input a number between 0 and " + listSize + ".";
+                    + "Please input a number between 0 and " + maxIndex + ".";
         }
         printDoubleLineMessage(message);
     }

--- a/src/test/java/seedu/parser/MainParserTest.java
+++ b/src/test/java/seedu/parser/MainParserTest.java
@@ -2,15 +2,15 @@ package seedu.parser;
 
 import org.junit.jupiter.api.BeforeEach;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
 import seedu.command.AddContactCommand;
 import seedu.command.Command;
 import seedu.command.DeleteContactCommand;
 import seedu.command.FailedCommand;
 import seedu.command.ViewCommand;
+import seedu.contact.ContactList;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class MainParserTest {
@@ -40,6 +40,7 @@ public class MainParserTest {
         return (T) result;
     }
 
+
     @Test
     public void parseDeleteCommand_validIndex_expectDeleteContactIndexMatch() {
         testIndex = 1;
@@ -47,6 +48,56 @@ public class MainParserTest {
         final DeleteContactCommand testResultCommand = getParsedCommand(testUserInput, DeleteContactCommand.class);
         assertEquals(testIndex, testResultCommand.getDeletedIndex());
     }
+
+    @Test
+    public void parseDeleteCommand_validIndexWithSpaces_expectDeleteContactIndexMatch() {
+        testIndex = 1;
+        testUserInput = "rm    " + testIndex;
+        final DeleteContactCommand testResultCommand = getParsedCommand(testUserInput, DeleteContactCommand.class);
+        assertEquals(testIndex, testResultCommand.getDeletedIndex());
+    }
+
+    @Test
+    public void parseDeleteCommand_missingIndex_expectFailedCommandType() {
+        testUserInput = "rm";
+        FailedCommandType expectedFailedCommandType = FailedCommandType.MISSING_ARG;
+        final FailedCommand actualFailedCommand = getParsedCommand(testUserInput, FailedCommand.class);
+        assertEquals(expectedFailedCommandType, actualFailedCommand.getType());
+    }
+
+    @Test
+    public void parseDeleteCommand_invalidNumber_expectFailedCommandType() {
+        testUserInput = "rm abc";
+        FailedCommandType expectedFailedCommandType = FailedCommandType.INVALID_INDEX;
+        final FailedCommand actualFailedCommand = getParsedCommand(testUserInput, FailedCommand.class);
+        assertEquals(expectedFailedCommandType, actualFailedCommand.getType());
+    }
+
+    @Test
+    public void parseDeleteCommand_invalidIndexFormatting_expectFailedCommandType() {
+        testUserInput = "rm 1 2";
+        FailedCommandType expectedFailedCommandType = FailedCommandType.INVALID_INDEX;
+        final FailedCommand actualFailedCommand = getParsedCommand(testUserInput, FailedCommand.class);
+        assertEquals(expectedFailedCommandType, actualFailedCommand.getType());
+    }
+
+    @Test
+    public void parseDeleteCommand_outOfRangeIndex_expectFailedCommandType() {
+        ContactList contactList = new ContactList();
+        testUserInput = "rm 3";
+        // adding 1 input contact into contactList
+        String addContactInput = "add -n wangyih -g ongzai";
+        AddContactCommand addContactCommand = getParsedCommand(addContactInput, AddContactCommand.class);
+        addContactCommand.setContactList(contactList);
+        addContactCommand.execute();
+        // trying to delete the contact with index 3 when there is only 1 contact (with index 0) in the contact list
+        DeleteContactCommand deleteContactCommand = getParsedCommand(testUserInput, DeleteContactCommand.class);
+        deleteContactCommand.setContactList(contactList);
+        int deletedIndex = deleteContactCommand.getDeletedIndex();
+
+        assertThrows(IndexOutOfBoundsException.class, () -> contactList.deleteContact(deletedIndex));
+    }
+
 
     @Test
     public void parseAddCommand_validInputsWithIrregularSpaces_expectAddContactCommand() {


### PR DESCRIPTION
Fixes #30 #31 
Implement JUnit tests for parsing Delete Commands in the Main Parser, as well as tweak exception catching for invalid indexes.