### PR TITLE
Save Personal details

### DIFF
--- a/src/main/java/seedu/command/InvalidDetailCommand.java
+++ b/src/main/java/seedu/command/InvalidDetailCommand.java
@@ -26,7 +26,7 @@ public class InvalidDetailCommand extends Command {
             ExceptionTextUi.invalidTelegramUsernameInput();
             break;
         case INVALID_LINKEDIN:
-            ExceptionTextUi.invalidLinkedinInput();
+            ExceptionTextUi.invalidLinkedinUsernameInput();
             break;
         case INVALID_MAIL:
             ExceptionTextUi.invalidEmailInput();

--- a/src/main/java/seedu/parser/AddPersonalContactParser.java
+++ b/src/main/java/seedu/parser/AddPersonalContactParser.java
@@ -64,7 +64,7 @@ public class AddPersonalContactParser extends RegexParser {
     }
 
     private void setGithubIfValid(String userInput) throws InvalidGithubUsernameException {
-        if (userInput.isEmpty()) {
+        if (userInput.isEmpty() || userInput == null) {
             isValidDetail = true;
         } else {
             checkGithubUsernameRegex(userInput);
@@ -87,7 +87,7 @@ public class AddPersonalContactParser extends RegexParser {
     }
 
     private void setTelegramIfValid(String userInput) throws InvalidTelegramUsernameException {
-        if (userInput.isEmpty()) {
+        if (userInput.isEmpty() || userInput == null) {
             isValidDetail = true;
         } else {
             checkTelegramUsernameRegex(userInput);
@@ -110,7 +110,7 @@ public class AddPersonalContactParser extends RegexParser {
     }
 
     private void setTwitterIfValid(String userInput) throws InvalidTwitterUsernameException {
-        if (userInput.isEmpty()) {
+        if (userInput.isEmpty() || userInput == null) {
             isValidDetail = true;
         } else {
             checkTwitterUsernameRegex(userInput);
@@ -133,7 +133,7 @@ public class AddPersonalContactParser extends RegexParser {
     }
 
     private void setEmailIfValid(String userInput) throws InvalidEmailException {
-        if (userInput.isEmpty()) {
+        if (userInput.isEmpty() || userInput == null) {
             isValidDetail = true;
         } else {
             checkEmailRegex(userInput);
@@ -156,7 +156,7 @@ public class AddPersonalContactParser extends RegexParser {
     }
 
     private void setLinkedInIfValid(String userInput) throws InvalidLinkedinUsernameException {
-        if (userInput.isEmpty()) {
+        if (userInput.isEmpty() || userInput == null) {
             isValidDetail = true;
         } else {
             checkLinkedinUsernameRegex(userInput);

--- a/src/main/java/seedu/parser/AddPersonalContactParser.java
+++ b/src/main/java/seedu/parser/AddPersonalContactParser.java
@@ -1,37 +1,121 @@
 package seedu.parser;
 
 
+import seedu.command.ExitCommand;
+import seedu.command.FailedCommand;
+import seedu.command.HelpCommand;
+import seedu.command.ListContactsCommand;
 import seedu.contact.Contact;
+import seedu.exception.InvalidGithubUsernameException;
 import seedu.exception.InvalidNameException;
+import seedu.exception.InvalidTelegramUsernameException;
 import seedu.ui.ExceptionTextUi;
 import seedu.ui.TextUi;
 import seedu.ui.UserInputTextUi;
 
 public class AddPersonalContactParser extends RegexParser {
+    public static final String NAME_FLAG = "n";
+    public static final String GITHUB_FLAG = "g";
+    public static final String TELEGRAM_FLAG = "te";
+    public static final String TWITTER_FLAG = "tw";
+    public static final String EMAIL_FLAG = "e";
+    public static final String LINKEDIN_FLAG = "l";
+
     private Contact personalContact = new Contact(null, null,null,null,
             null,null);
+    private boolean isValidDetail = false;
 
     public AddPersonalContactParser() {
         TextUi.welcomeMessage();
         promptPersonalName();
+        promptPersonalGithubUsername();
+        promptPersonalTelegramUsername();
         TextUi.greetingMessage(personalContact);
     }
 
     private void promptPersonalName() {
-        boolean isValid = false;
-        String personalName = "";
+        isValidDetail = false;
         do {
             try {
-                personalName = UserInputTextUi.getUserInput();
+                String personalName = UserInputTextUi.getUserInput();
                 checkNameRegex(personalName);
                 //checkNameRegex passes so the name must be valid
-                isValid = true;
+                isValidDetail = true;
+                this.personalContact.setName(personalName);
             } catch (InvalidNameException e) {
                 ExceptionTextUi.invalidPersonalNameErrorMessage();
             }
-        } while (!isValid);
-        this.personalContact.setName(personalName);
+        } while (!isValidDetail);
     }
+
+    private void promptPersonalGithubUsername() {
+        isValidDetail = false;
+        TextUi.promptPersonalGithubUsernameMessage(this.personalContact.getName());
+        do {
+            try {
+                String personalGithubUsername = UserInputTextUi.getUserInput();
+                setGithubIfValid(personalGithubUsername);
+            } catch (InvalidGithubUsernameException e) {
+                ExceptionTextUi.invalidPersonalGithubUsernameErrorMessage();
+            }
+        } while (!isValidDetail);
+    }
+
+    public void setGithubIfValid(String userInput) throws InvalidGithubUsernameException {
+        if (userInput.isEmpty()) {
+            isValidDetail = true;
+        } else {
+            checkGithubUsernameRegex(userInput);
+            isValidDetail = true;
+            this.personalContact.setGithub(userInput);
+        }
+    }
+
+    private void promptPersonalTelegramUsername() {
+        isValidDetail = false;
+        TextUi.promptPersonalTelegramUsernameMessage();
+        do {
+            try {
+                String personalTelegram = UserInputTextUi.getUserInput();
+                setTelegramIfValid(personalTelegram);
+            } catch (InvalidTelegramUsernameException e) {
+                ExceptionTextUi.invalidPersonalTelegramUsernameErrorMessage();
+            }
+        } while (!isValidDetail);
+    }
+
+    public void setTelegramIfValid(String userInput) throws InvalidTelegramUsernameException {
+        if (userInput.isEmpty()) {
+            isValidDetail = true;
+        } else {
+            checkTelegramUsernameRegex(userInput);
+            isValidDetail = true;
+            this.personalContact.setTelegram(userInput);
+        }
+    }
+
+
+//    private void setDetailsIfValid(String userInput, String flag) throws InvalidGithubUsernameException,
+//            InvalidTelegramUsernameException {
+//        if (userInput.isEmpty()) {
+//            isValidDetail = true;
+//            return;
+//        }
+//        switch (flag) {
+//        case GITHUB_FLAG:
+//            checkGithubUsernameRegex(userInput);
+//            isValidDetail = true;
+//            this.personalContact.setGithub(userInput);
+//            break;
+//        case TELEGRAM_FLAG:
+//            checkTelegramUsernameRegex(userInput);
+//            isValidDetail = true;
+//            this.personalContact.setTelegram(userInput);
+//            break;
+//        default:
+//            return;
+//        }
+//    }
 
     public Contact getPersonalContact() {
         return personalContact;

--- a/src/main/java/seedu/parser/AddPersonalContactParser.java
+++ b/src/main/java/seedu/parser/AddPersonalContactParser.java
@@ -18,13 +18,21 @@ public class AddPersonalContactParser extends RegexParser {
 
     public AddPersonalContactParser() {
         TextUi.welcomeMessage();
+    }
+
+
+    public void startCollectingPersonalDetails() {
         promptPersonalName();
-        promptPersonalGithubUsername();
-        promptPersonalTelegramUsername();
-        promptPersonalTwitterUsername();
-        promptPersonalEmailAddress();
-        promptPersonalLinkedInUsername();
         TextUi.greetingMessage(personalContact);
+        String userConfirmation = UserInputTextUi.getUserConfirmation();
+        if (userConfirmation != null || userConfirmation.isBlank()) {
+            promptPersonalGithubUsername();
+            promptPersonalTelegramUsername();
+            promptPersonalTwitterUsername();
+            promptPersonalEmailAddress();
+            promptPersonalLinkedInUsername();
+            TextUi.finishSetUpMessage();
+        }
     }
 
     private void promptPersonalName() {

--- a/src/main/java/seedu/parser/AddPersonalContactParser.java
+++ b/src/main/java/seedu/parser/AddPersonalContactParser.java
@@ -23,6 +23,7 @@ public class AddPersonalContactParser extends RegexParser {
         promptPersonalTelegramUsername();
         promptPersonalTwitterUsername();
         promptPersonalEmailAddress();
+        promptPersonalLinkedInUsername();
         TextUi.greetingMessage(personalContact);
     }
 
@@ -133,6 +134,28 @@ public class AddPersonalContactParser extends RegexParser {
         }
     }
 
+    private void promptPersonalLinkedInUsername() {
+        isValidDetail = false;
+        TextUi.promptPersonalLinkedInUsernameMessage();
+        do {
+            try {
+                String personalLinkedIn = UserInputTextUi.getUserInput();
+                setLinkedInIfValid(personalLinkedIn);
+            } catch (InvalidLinkedinUsernameException e) {
+                ExceptionTextUi.invalidPersonalLinkedinUsernameErrorMessage();
+            }
+        } while (!isValidDetail);
+    }
+
+    private void setLinkedInIfValid(String userInput) throws InvalidLinkedinUsernameException {
+        if (userInput.isEmpty()) {
+            isValidDetail = true;
+        } else {
+            checkLinkedinUsernameRegex(userInput);
+            isValidDetail = true;
+            this.personalContact.setLinkedin(userInput);
+        }
+    }
 
     public Contact getPersonalContact() {
         return personalContact;

--- a/src/main/java/seedu/parser/AddPersonalContactParser.java
+++ b/src/main/java/seedu/parser/AddPersonalContactParser.java
@@ -1,27 +1,17 @@
 package seedu.parser;
 
-
-import seedu.command.ExitCommand;
-import seedu.command.FailedCommand;
-import seedu.command.HelpCommand;
-import seedu.command.ListContactsCommand;
 import seedu.contact.Contact;
 import seedu.exception.InvalidGithubUsernameException;
 import seedu.exception.InvalidNameException;
 import seedu.exception.InvalidTelegramUsernameException;
 import seedu.exception.InvalidTwitterUsernameException;
+import seedu.exception.InvalidLinkedinUsernameException;
+import seedu.exception.InvalidEmailException;
 import seedu.ui.ExceptionTextUi;
 import seedu.ui.TextUi;
 import seedu.ui.UserInputTextUi;
 
 public class AddPersonalContactParser extends RegexParser {
-    public static final String NAME_FLAG = "n";
-    public static final String GITHUB_FLAG = "g";
-    public static final String TELEGRAM_FLAG = "te";
-    public static final String TWITTER_FLAG = "tw";
-    public static final String EMAIL_FLAG = "e";
-    public static final String LINKEDIN_FLAG = "l";
-
     private Contact personalContact = new Contact(null, null,null,null,
             null,null);
     private boolean isValidDetail = false;
@@ -32,6 +22,7 @@ public class AddPersonalContactParser extends RegexParser {
         promptPersonalGithubUsername();
         promptPersonalTelegramUsername();
         promptPersonalTwitterUsername();
+        promptPersonalEmailAddress();
         TextUi.greetingMessage(personalContact);
     }
 
@@ -63,7 +54,7 @@ public class AddPersonalContactParser extends RegexParser {
         } while (!isValidDetail);
     }
 
-    public void setGithubIfValid(String userInput) throws InvalidGithubUsernameException {
+    private void setGithubIfValid(String userInput) throws InvalidGithubUsernameException {
         if (userInput.isEmpty()) {
             isValidDetail = true;
         } else {
@@ -86,7 +77,7 @@ public class AddPersonalContactParser extends RegexParser {
         } while (!isValidDetail);
     }
 
-    public void setTelegramIfValid(String userInput) throws InvalidTelegramUsernameException {
+    private void setTelegramIfValid(String userInput) throws InvalidTelegramUsernameException {
         if (userInput.isEmpty()) {
             isValidDetail = true;
         } else {
@@ -109,7 +100,7 @@ public class AddPersonalContactParser extends RegexParser {
         } while (!isValidDetail);
     }
 
-    public void setTwitterIfValid(String userInput) throws InvalidTwitterUsernameException {
+    private void setTwitterIfValid(String userInput) throws InvalidTwitterUsernameException {
         if (userInput.isEmpty()) {
             isValidDetail = true;
         } else {
@@ -119,28 +110,29 @@ public class AddPersonalContactParser extends RegexParser {
         }
     }
 
+    private void promptPersonalEmailAddress() {
+        isValidDetail = false;
+        TextUi.promptPersonalEmailMessage();
+        do {
+            try {
+                String personalEmail = UserInputTextUi.getUserInput();
+                setEmailIfValid(personalEmail);
+            } catch (InvalidEmailException e) {
+                ExceptionTextUi.invalidPersonalEmailErrorMessage();
+            }
+        } while (!isValidDetail);
+    }
 
-//    private void setDetailsIfValid(String userInput, String flag) throws InvalidGithubUsernameException,
-//            InvalidTelegramUsernameException {
-//        if (userInput.isEmpty()) {
-//            isValidDetail = true;
-//            return;
-//        }
-//        switch (flag) {
-//        case GITHUB_FLAG:
-//            checkGithubUsernameRegex(userInput);
-//            isValidDetail = true;
-//            this.personalContact.setGithub(userInput);
-//            break;
-//        case TELEGRAM_FLAG:
-//            checkTelegramUsernameRegex(userInput);
-//            isValidDetail = true;
-//            this.personalContact.setTelegram(userInput);
-//            break;
-//        default:
-//            return;
-//        }
-//    }
+    private void setEmailIfValid(String userInput) throws InvalidEmailException {
+        if (userInput.isEmpty()) {
+            isValidDetail = true;
+        } else {
+            checkEmailRegex(userInput);
+            isValidDetail = true;
+            this.personalContact.setEmail(userInput);
+        }
+    }
+
 
     public Contact getPersonalContact() {
         return personalContact;

--- a/src/main/java/seedu/parser/AddPersonalContactParser.java
+++ b/src/main/java/seedu/parser/AddPersonalContactParser.java
@@ -9,6 +9,7 @@ import seedu.contact.Contact;
 import seedu.exception.InvalidGithubUsernameException;
 import seedu.exception.InvalidNameException;
 import seedu.exception.InvalidTelegramUsernameException;
+import seedu.exception.InvalidTwitterUsernameException;
 import seedu.ui.ExceptionTextUi;
 import seedu.ui.TextUi;
 import seedu.ui.UserInputTextUi;
@@ -30,6 +31,7 @@ public class AddPersonalContactParser extends RegexParser {
         promptPersonalName();
         promptPersonalGithubUsername();
         promptPersonalTelegramUsername();
+        promptPersonalTwitterUsername();
         TextUi.greetingMessage(personalContact);
     }
 
@@ -91,6 +93,29 @@ public class AddPersonalContactParser extends RegexParser {
             checkTelegramUsernameRegex(userInput);
             isValidDetail = true;
             this.personalContact.setTelegram(userInput);
+        }
+    }
+
+    private void promptPersonalTwitterUsername() {
+        isValidDetail = false;
+        TextUi.promptPersonalTwitterUsernameMessage();
+        do {
+            try {
+                String personalTwitter = UserInputTextUi.getUserInput();
+                setTwitterIfValid(personalTwitter);
+            } catch (InvalidTwitterUsernameException e) {
+                ExceptionTextUi.invalidPersonalTwitterUsernameErrorMessage();
+            }
+        } while (!isValidDetail);
+    }
+
+    public void setTwitterIfValid(String userInput) throws InvalidTwitterUsernameException {
+        if (userInput.isEmpty()) {
+            isValidDetail = true;
+        } else {
+            checkTwitterUsernameRegex(userInput);
+            isValidDetail = true;
+            this.personalContact.setTwitter(userInput);
         }
     }
 

--- a/src/main/java/seedu/parser/AddPersonalContactParser.java
+++ b/src/main/java/seedu/parser/AddPersonalContactParser.java
@@ -20,22 +20,21 @@ public class AddPersonalContactParser extends RegexParser {
         TextUi.welcomeMessage();
     }
 
-
     public void startCollectingPersonalDetails() {
-        promptPersonalName();
+        parsePersonalName();
         TextUi.greetingMessage(personalContact);
         String userConfirmation = UserInputTextUi.getUserConfirmation();
         if (userConfirmation != null || userConfirmation.isBlank()) {
-            promptPersonalGithubUsername();
-            promptPersonalTelegramUsername();
-            promptPersonalTwitterUsername();
-            promptPersonalEmailAddress();
-            promptPersonalLinkedInUsername();
+            parsePersonalGithubUsername();
+            parsePersonalTelegramUsername();
+            parsePersonalTwitterUsername();
+            parsePersonalEmailAddress();
+            parsePersonalLinkedInUsername();
             TextUi.finishSetUpMessage();
         }
     }
 
-    private void promptPersonalName() {
+    private void parsePersonalName() {
         isValidDetail = false;
         do {
             try {
@@ -50,7 +49,7 @@ public class AddPersonalContactParser extends RegexParser {
         } while (!isValidDetail);
     }
 
-    private void promptPersonalGithubUsername() {
+    private void parsePersonalGithubUsername() {
         isValidDetail = false;
         TextUi.promptPersonalGithubUsernameMessage(this.personalContact.getName());
         do {
@@ -73,7 +72,7 @@ public class AddPersonalContactParser extends RegexParser {
         }
     }
 
-    private void promptPersonalTelegramUsername() {
+    private void parsePersonalTelegramUsername() {
         isValidDetail = false;
         TextUi.promptPersonalTelegramUsernameMessage();
         do {
@@ -96,7 +95,7 @@ public class AddPersonalContactParser extends RegexParser {
         }
     }
 
-    private void promptPersonalTwitterUsername() {
+    private void parsePersonalTwitterUsername() {
         isValidDetail = false;
         TextUi.promptPersonalTwitterUsernameMessage();
         do {
@@ -119,7 +118,7 @@ public class AddPersonalContactParser extends RegexParser {
         }
     }
 
-    private void promptPersonalEmailAddress() {
+    private void parsePersonalEmailAddress() {
         isValidDetail = false;
         TextUi.promptPersonalEmailMessage();
         do {
@@ -142,7 +141,7 @@ public class AddPersonalContactParser extends RegexParser {
         }
     }
 
-    private void promptPersonalLinkedInUsername() {
+    private void parsePersonalLinkedInUsername() {
         isValidDetail = false;
         TextUi.promptPersonalLinkedInUsernameMessage();
         do {

--- a/src/main/java/seedu/storage/Storage.java
+++ b/src/main/java/seedu/storage/Storage.java
@@ -79,6 +79,7 @@ public class Storage {
             isFirstRun = true;
             // get new contact's name
             AddPersonalContactParser addPersonalContactParser = new AddPersonalContactParser();
+            addPersonalContactParser.startCollectingPersonalDetails();
             Contact personalContact = addPersonalContactParser.getPersonalContact();
             ContactsEncoder.savePersonalContact(personalContactFilePath, personalContact);
             return personalContact;

--- a/src/main/java/seedu/ui/ExceptionTextUi.java
+++ b/src/main/java/seedu/ui/ExceptionTextUi.java
@@ -79,6 +79,16 @@ public class ExceptionTextUi {
         printDoubleLineMessage(message);
     }
 
+    public static void invalidPersonalLinkedinUsernameErrorMessage() {
+        String message = "The linkedin username is not correctly formatted,\n"
+                + "Rules for Linkedin username :\n"
+                + "    * Lowercase letters only\n"
+                + "    * Numbers, underscore and hyphen allowed\n"
+                + "    * Length between 3 to 100 characters\n\n"
+                + "Please enter your linkedin username again\n"
+                + "or press ENTER to skip.";
+        printDoubleLineMessage(message);
+    }
 
     // Error Messages
     public static void fileErrorMessage(String contactFilePath) {

--- a/src/main/java/seedu/ui/ExceptionTextUi.java
+++ b/src/main/java/seedu/ui/ExceptionTextUi.java
@@ -31,6 +31,7 @@ public class ExceptionTextUi {
                 + "    * Cannot be \"null\"\n\n"
                 + "Please enter your name again.";
         printDoubleLineMessage(message);
+        System.out.print("Name:");
     }
 
     public static void invalidPersonalGithubUsernameErrorMessage() {
@@ -44,6 +45,7 @@ public class ExceptionTextUi {
                 + "Please enter your github username again\n"
                 + "or press ENTER to skip.";
         printDoubleLineMessage(message);
+        System.out.print("GitHub Username:");
     }
 
     public static void invalidPersonalTelegramUsernameErrorMessage() {
@@ -55,6 +57,7 @@ public class ExceptionTextUi {
                 + "Please enter your telegram username again\n"
                 + "or press ENTER to skip.";
         printDoubleLineMessage(message);
+        System.out.print("Telegram Handle: @");
     }
 
     public static void invalidPersonalTwitterUsernameErrorMessage() {
@@ -66,6 +69,7 @@ public class ExceptionTextUi {
                 + "Please enter your twitter username again\n"
                 + "or press ENTER to skip.";
         printDoubleLineMessage(message);
+        System.out.print("Twitter Username:");
     }
 
     public static void invalidPersonalEmailErrorMessage() {
@@ -77,6 +81,7 @@ public class ExceptionTextUi {
                 + "Please enter your email again\n"
                 + "or press ENTER to skip.";
         printDoubleLineMessage(message);
+        System.out.print("Email Address:");
     }
 
     public static void invalidPersonalLinkedinUsernameErrorMessage() {
@@ -88,6 +93,7 @@ public class ExceptionTextUi {
                 + "Please enter your linkedin username again\n"
                 + "or press ENTER to skip.";
         printDoubleLineMessage(message);
+        System.out.print("LinkedIn Username:");
     }
 
     // Error Messages

--- a/src/main/java/seedu/ui/ExceptionTextUi.java
+++ b/src/main/java/seedu/ui/ExceptionTextUi.java
@@ -79,16 +79,6 @@ public class ExceptionTextUi {
         printDoubleLineMessage(message);
     }
 
-    public static void invalidPersonalLinkedinUsernameErrorMessage() {
-        String message = "The linkedin username is not correctly formatted,\n"
-                + "Rules for Linkedin username :\n"
-                + "    * Lowercase letters only\n"
-                + "    * Numbers, underscore and hyphen allowed\n"
-                + "    * Length between 3 to 100 characters\n\n"
-                + "Please enter your linkedin username again\n"
-                + "or press ENTER to skip.";
-        printDoubleLineMessage(message);
-    }
 
     // Error Messages
     public static void fileErrorMessage(String contactFilePath) {

--- a/src/main/java/seedu/ui/ExceptionTextUi.java
+++ b/src/main/java/seedu/ui/ExceptionTextUi.java
@@ -33,6 +33,63 @@ public class ExceptionTextUi {
         printDoubleLineMessage(message);
     }
 
+    public static void invalidPersonalGithubUsernameErrorMessage() {
+        String message = "The github username is not correctly formatted,\n"
+                + "Rules for Github username :\n"
+                + "    * Only contain alphanumeric characters or hyphens\n"
+                + "    * Only lowercase allowed\n"
+                + "    * Maximum 39 characters allowed\n"
+                + "    * Cannot have multiple consecutive hyphens\n"
+                + "    * Cannot begin or end with a hyphen\n\n"
+                + "Please enter your github username again\n"
+                + "or press ENTER to skip.";
+        printDoubleLineMessage(message);
+    }
+
+    public static void invalidPersonalTelegramUsernameErrorMessage() {
+        String message = "The telegram username is not correctly formatted,\n"
+                + "Rules for Telegram username :\n"
+                + "    * Uppercase and lowercase letters allowed\n"
+                + "    * Numbers and underscore allowed\n"
+                + "    * Length at-least 5 characters\n\n"
+                + "Please enter your telegram username again\n"
+                + "or press ENTER to skip.";
+        printDoubleLineMessage(message);
+    }
+
+    public static void invalidPersonalTwitterUsernameErrorMessage() {
+        String message = "The twitter username is not correctly formatted,\n"
+                + "Rules for Twitter username :\n"
+                + "    * Lowercase letters only\n"
+                + "    * Numbers and underscore allowed\n"
+                + "    * Maximum 15 characters allowed\n\n"
+                + "Please enter your twitter username again\n"
+                + "or press ENTER to skip.";
+        printDoubleLineMessage(message);
+    }
+
+    public static void invalidPersonalEmailErrorMessage() {
+        String message = "The email id is not correctly formatted,\n"
+                + "Rules for email id :\n"
+                + "    * Lowercase letters only\n"
+                + "    * Numbers, underscore, hyphen and dot allowed\n"
+                + "    * @ cannot be at the start or end\n\n"
+                + "Please enter your email again\n"
+                + "or press ENTER to skip.";
+        printDoubleLineMessage(message);
+    }
+
+    public static void invalidPersonalLinkedinUsernameErrorMessage() {
+        String message = "The linkedin username is not correctly formatted,\n"
+                + "Rules for Linkedin username :\n"
+                + "    * Lowercase letters only\n"
+                + "    * Numbers, underscore and hyphen allowed\n"
+                + "    * Length between 3 to 100 characters\n\n"
+                + "Please enter your linkedin username again\n"
+                + "or press ENTER to skip.";
+        printDoubleLineMessage(message);
+    }
+
     // Error Messages
     public static void fileErrorMessage(String contactFilePath) {
         String message = "ConTech is unfortunately unable to access / create a\n" + " save file at " + contactFilePath
@@ -135,7 +192,7 @@ public class ExceptionTextUi {
                 + "    * Only lowercase allowed\n"
                 + "    * Maximum 39 characters allowed\n"
                 + "    * Cannot have multiple consecutive hyphens\n"
-                + "    * Cannot begin or end with a hyphen\n";
+                + "    * Cannot begin or end with a hyphen";
         printDoubleLineMessage(message);
     }
 
@@ -167,7 +224,7 @@ public class ExceptionTextUi {
         printDoubleLineMessage(message);
     }
 
-    public static void invalidLinkedinInput() {
+    public static void invalidLinkedinUsernameInput() {
         String message = "The linkedin username is not correctly formatted,\n"
                 + "Rules for Linkedin username :\n"
                 + "    * Lowercase letters only\n"

--- a/src/main/java/seedu/ui/TextUi.java
+++ b/src/main/java/seedu/ui/TextUi.java
@@ -48,15 +48,23 @@ public abstract class TextUi {
     public static void greetingMessage(Contact personalContact) {
         String message = "Hello there, " + personalContact.getName() + ".\n\n"
                 + "This is ConTech, your very own contact tracking application\n"
-                + "to manage computing-related contacts, like GitHub Accounts\n"
-                + "or even Emails.\n\n"
-                + "Enter \"help\" to see what you can do with ConTech.";
+                + "to manage tech-related contacts, like GitHub Accounts or\n"
+                + "even Emails.\n\n"
+                + "Before we start, let's set up your personal contact, shall\n"
+                + "we?\n\n"
+                + "Enter anything to continue...";
+        printDoubleLineMessage(message);
+    }
+
+    public static void finishSetUpMessage() {
+        String message = "You have successfully set up your own personal contact.\n"
+                + "Don't worry, you can always edit your personal details \n"
+                + "later on.\n\nTo see what you can do with ConTech, enter \"help\".";
         printDoubleLineMessage(message);
     }
 
     public static void promptPersonalGithubUsernameMessage(String personalName) {
-        String message = "Hello, " + personalName + ".\n\n"
-                + "Please provide us with your Github Username\n"
+        String message = "Please provide us with your Github Username\n"
                 + "or press ENTER if you would like to skip.";
         printDoubleLineMessage(message);
     }

--- a/src/main/java/seedu/ui/TextUi.java
+++ b/src/main/java/seedu/ui/TextUi.java
@@ -54,6 +54,37 @@ public abstract class TextUi {
         printDoubleLineMessage(message);
     }
 
+    public static void promptPersonalGithubUsernameMessage(String personalName) {
+        String message = "Hello, " + personalName + ".\n\n"
+                + "Please provide us with your Github Username\n"
+                + "or press ENTER if you would like to skip.";
+        printDoubleLineMessage(message);
+    }
+
+    public static void promptPersonalTelegramUsernameMessage() {
+        String message = "Please provide us with your Telegram Handle\n"
+                + "or press ENTER if you would like to skip.";
+        printDoubleLineMessage(message);
+    }
+
+    public static void promptPersonalTwitterUsernameMessage() {
+        String message = "Please provide us with your Twitter Username\n"
+                + "or press ENTER if you would like to skip.";
+        printDoubleLineMessage(message);
+    }
+
+    public static void promptPersonalEmailMessage() {
+        String message = "Please provide us with your Email Address\n"
+                + "or press ENTER if you would like to skip.";
+        printDoubleLineMessage(message);
+    }
+
+    public static void promptPersonalLinkedInUsernameMessage() {
+        String message = "Please provide us with your LinkedIn Username\n"
+                + "or press ENTER if you would like to skip.";
+        printDoubleLineMessage(message);
+    }
+
     public static void createNewContactFileMessage(String contactFilePath) {
         String message = "As ConTech is unable to find your saved data,\n" + " it has created a new one for you at:\n"
                 + contactFilePath;

--- a/src/main/java/seedu/ui/TextUi.java
+++ b/src/main/java/seedu/ui/TextUi.java
@@ -36,11 +36,12 @@ public abstract class TextUi {
         String message = "Welcome to ConTech, your personal contact tracker.\n"
                 + "Can I get your name?";
         printBottomLineMessage(message);
+        System.out.print("Name:");
     }
 
     public static void welcomeBackMessage(Contact personalContact) {
         printDoubleLineMessage(LOGO);
-        String message = "Hello, " + personalContact.getName() + ". Welcome back to ConTech, "
+        String message = "Hello, " + personalContact.getName() + ". \nWelcome back to ConTech, "
                 + "your personal \ncontact tracker.";
         printBottomLineMessage(message);
     }
@@ -67,30 +68,35 @@ public abstract class TextUi {
         String message = "Please provide us with your Github Username\n"
                 + "or press ENTER if you would like to skip.";
         printDoubleLineMessage(message);
+        System.out.print("GitHub Username:");
     }
 
     public static void promptPersonalTelegramUsernameMessage() {
         String message = "Please provide us with your Telegram Handle\n"
                 + "or press ENTER if you would like to skip.";
         printDoubleLineMessage(message);
+        System.out.print("Telegram Handle: @");
     }
 
     public static void promptPersonalTwitterUsernameMessage() {
         String message = "Please provide us with your Twitter Username\n"
                 + "or press ENTER if you would like to skip.";
         printDoubleLineMessage(message);
+        System.out.print("Twitter Username:");
     }
 
     public static void promptPersonalEmailMessage() {
         String message = "Please provide us with your Email Address\n"
                 + "or press ENTER if you would like to skip.";
         printDoubleLineMessage(message);
+        System.out.print("Email Address:");
     }
 
     public static void promptPersonalLinkedInUsernameMessage() {
         String message = "Please provide us with your LinkedIn Username\n"
                 + "or press ENTER if you would like to skip.";
         printDoubleLineMessage(message);
+        System.out.print("LinkedIn Username:");
     }
 
     public static void createNewContactFileMessage(String contactFilePath) {

--- a/text-ui-test/ACTUAL.TXT
+++ b/text-ui-test/ACTUAL.TXT
@@ -23,14 +23,61 @@ Welcome to ConTech, your personal contact tracker.
 Can I get your name?
 ____________________________________________________________
 
-____________________________________________________________
+Name:____________________________________________________________
 Hello there, Le Zong.
 
 This is ConTech, your very own contact tracking application
-to manage computing-related contacts, like GitHub Accounts
-or even Emails.
+to manage tech-related contacts, like GitHub Accounts or
+even Emails.
 
-Enter "help" to see what you can do with ConTech.
+Before we start, let's set up your personal contact, shall
+we?
+
+Enter anything to continue...
+____________________________________________________________
+
+____________________________________________________________
+Please provide us with your Github Username
+or press ENTER if you would like to skip.
+____________________________________________________________
+
+GitHub Username:____________________________________________________________
+Please provide us with your Telegram Handle
+or press ENTER if you would like to skip.
+____________________________________________________________
+
+Telegram Handle: @____________________________________________________________
+Please provide us with your Twitter Username
+or press ENTER if you would like to skip.
+____________________________________________________________
+
+Twitter Username:____________________________________________________________
+Please provide us with your Email Address
+or press ENTER if you would like to skip.
+____________________________________________________________
+
+Email Address:____________________________________________________________
+The email id is not correctly formatted,
+Rules for email id :
+    * Lowercase letters only
+    * Numbers, underscore, hyphen and dot allowed
+    * @ cannot be at the start or end
+
+Please enter your email again
+or press ENTER to skip.
+____________________________________________________________
+
+Email Address:____________________________________________________________
+Please provide us with your LinkedIn Username
+or press ENTER if you would like to skip.
+____________________________________________________________
+
+LinkedIn Username:____________________________________________________________
+You have successfully set up your own personal contact.
+Don't worry, you can always edit your personal details 
+later on.
+
+To see what you can do with ConTech, enter "help".
 ____________________________________________________________
 
 ____________________________________________________________
@@ -315,7 +362,6 @@ Rules for Github username :
     * Maximum 39 characters allowed
     * Cannot have multiple consecutive hyphens
     * Cannot begin or end with a hyphen
-
 ____________________________________________________________
 
 ____________________________________________________________
@@ -326,7 +372,6 @@ Rules for Github username :
     * Maximum 39 characters allowed
     * Cannot have multiple consecutive hyphens
     * Cannot begin or end with a hyphen
-
 ____________________________________________________________
 
 ____________________________________________________________

--- a/text-ui-test/EXPECTED-UNIX.TXT
+++ b/text-ui-test/EXPECTED-UNIX.TXT
@@ -23,14 +23,61 @@ Welcome to ConTech, your personal contact tracker.
 Can I get your name?
 ____________________________________________________________
 
-____________________________________________________________
+Name:____________________________________________________________
 Hello there, Le Zong.
 
 This is ConTech, your very own contact tracking application
-to manage computing-related contacts, like GitHub Accounts
-or even Emails.
+to manage tech-related contacts, like GitHub Accounts or
+even Emails.
 
-Enter "help" to see what you can do with ConTech.
+Before we start, let's set up your personal contact, shall
+we?
+
+Enter anything to continue...
+____________________________________________________________
+
+____________________________________________________________
+Please provide us with your Github Username
+or press ENTER if you would like to skip.
+____________________________________________________________
+
+GitHub Username:____________________________________________________________
+Please provide us with your Telegram Handle
+or press ENTER if you would like to skip.
+____________________________________________________________
+
+Telegram Handle: @____________________________________________________________
+Please provide us with your Twitter Username
+or press ENTER if you would like to skip.
+____________________________________________________________
+
+Twitter Username:____________________________________________________________
+Please provide us with your Email Address
+or press ENTER if you would like to skip.
+____________________________________________________________
+
+Email Address:____________________________________________________________
+The email id is not correctly formatted,
+Rules for email id :
+    * Lowercase letters only
+    * Numbers, underscore, hyphen and dot allowed
+    * @ cannot be at the start or end
+
+Please enter your email again
+or press ENTER to skip.
+____________________________________________________________
+
+Email Address:____________________________________________________________
+Please provide us with your LinkedIn Username
+or press ENTER if you would like to skip.
+____________________________________________________________
+
+LinkedIn Username:____________________________________________________________
+You have successfully set up your own personal contact.
+Don't worry, you can always edit your personal details 
+later on.
+
+To see what you can do with ConTech, enter "help".
 ____________________________________________________________
 
 ____________________________________________________________
@@ -315,7 +362,6 @@ Rules for Github username :
     * Maximum 39 characters allowed
     * Cannot have multiple consecutive hyphens
     * Cannot begin or end with a hyphen
-
 ____________________________________________________________
 
 ____________________________________________________________
@@ -326,7 +372,6 @@ Rules for Github username :
     * Maximum 39 characters allowed
     * Cannot have multiple consecutive hyphens
     * Cannot begin or end with a hyphen
-
 ____________________________________________________________
 
 ____________________________________________________________

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -23,14 +23,61 @@ Welcome to ConTech, your personal contact tracker.
 Can I get your name?
 ____________________________________________________________
 
-____________________________________________________________
+Name:____________________________________________________________
 Hello there, Le Zong.
 
 This is ConTech, your very own contact tracking application
-to manage computing-related contacts, like GitHub Accounts
-or even Emails.
+to manage tech-related contacts, like GitHub Accounts or
+even Emails.
 
-Enter "help" to see what you can do with ConTech.
+Before we start, let's set up your personal contact, shall
+we?
+
+Enter anything to continue...
+____________________________________________________________
+
+____________________________________________________________
+Please provide us with your Github Username
+or press ENTER if you would like to skip.
+____________________________________________________________
+
+GitHub Username:____________________________________________________________
+Please provide us with your Telegram Handle
+or press ENTER if you would like to skip.
+____________________________________________________________
+
+Telegram Handle: @____________________________________________________________
+Please provide us with your Twitter Username
+or press ENTER if you would like to skip.
+____________________________________________________________
+
+Twitter Username:____________________________________________________________
+Please provide us with your Email Address
+or press ENTER if you would like to skip.
+____________________________________________________________
+
+Email Address:____________________________________________________________
+The email id is not correctly formatted,
+Rules for email id :
+    * Lowercase letters only
+    * Numbers, underscore, hyphen and dot allowed
+    * @ cannot be at the start or end
+
+Please enter your email again
+or press ENTER to skip.
+____________________________________________________________
+
+Email Address:____________________________________________________________
+Please provide us with your LinkedIn Username
+or press ENTER if you would like to skip.
+____________________________________________________________
+
+LinkedIn Username:____________________________________________________________
+You have successfully set up your own personal contact.
+Don't worry, you can always edit your personal details 
+later on.
+
+To see what you can do with ConTech, enter "help".
 ____________________________________________________________
 
 ____________________________________________________________
@@ -315,7 +362,6 @@ Rules for Github username :
     * Maximum 39 characters allowed
     * Cannot have multiple consecutive hyphens
     * Cannot begin or end with a hyphen
-
 ____________________________________________________________
 
 ____________________________________________________________
@@ -326,7 +372,6 @@ Rules for Github username :
     * Maximum 39 characters allowed
     * Cannot have multiple consecutive hyphens
     * Cannot begin or end with a hyphen
-
 ____________________________________________________________
 
 ____________________________________________________________

--- a/text-ui-test/input.txt
+++ b/text-ui-test/input.txt
@@ -1,4 +1,11 @@
 Le Zong
+
+lezongmun
+lezongg
+
+@gmail.com
+lezongmun@gmail.com
+
 rm 1
 add -n ng andre -g ng-andre
 rm 2


### PR DESCRIPTION
Fixes #73.
In the User's first run of the application, the User will now be prompted to provide their Name, GitHub, Telegram, Twitter, Email, and LinkedIn account usernames. These details will be saved in the personalContactFile, and loaded in subsequent runs of the application. The UI when prompting for the User's personal details has also been updated and improved.

