### PR TITLE
Duplicate catcher for add and edit features

### DIFF
--- a/src/main/java/seedu/command/AddContactCommand.java
+++ b/src/main/java/seedu/command/AddContactCommand.java
@@ -104,5 +104,10 @@ public class AddContactCommand extends Command {
         }
         return false;
     }
+
+    public Boolean duplicateField(String input, String saved) {
+        return stringCleaner(saved).equals(stringCleaner(input));
+    }
+
     }
 }

--- a/src/main/java/seedu/command/AddContactCommand.java
+++ b/src/main/java/seedu/command/AddContactCommand.java
@@ -1,8 +1,12 @@
 package seedu.command;
 
 import seedu.contact.Contact;
+import seedu.contact.ContactList;
 import seedu.contact.DetailType;
 import seedu.ui.TextUi;
+import seedu.ui.UserInputTextUi;
+
+import java.util.ArrayList;
 
 public class AddContactCommand extends Command {
     private final String name;
@@ -47,7 +51,13 @@ public class AddContactCommand extends Command {
 
     public void execute() {
         Contact addedContact = new Contact(name, github, linkedin, telegram, twitter, email);
-        contactList.addContact(addedContact);
-        TextUi.addContactMessage(addedContact, contactList.getListSize());
+        if (duplicateCatcher(addedContact, contactList)) {
+            TextUi.ignoreAddContact();
+        } else {
+            contactList.addContact(addedContact);
+            TextUi.addContactMessage(addedContact, contactList.getListSize());
+        }
+    }
+
     }
 }

--- a/src/main/java/seedu/command/AddContactCommand.java
+++ b/src/main/java/seedu/command/AddContactCommand.java
@@ -109,5 +109,7 @@ public class AddContactCommand extends Command {
         return stringCleaner(saved).equals(stringCleaner(input));
     }
 
+    public String stringCleaner(String input) {
+        return input.replace(" ", "").toLowerCase();
     }
 }

--- a/src/main/java/seedu/command/AddContactCommand.java
+++ b/src/main/java/seedu/command/AddContactCommand.java
@@ -59,5 +59,50 @@ public class AddContactCommand extends Command {
         }
     }
 
+    public Boolean duplicateCatcher(Contact addedContact, ContactList contactList) {
+        ArrayList<Integer> duplicatedIndex = new ArrayList<>();
+        for (int i = 0; i < contactList.getListSize(); i++) {
+            Contact currentContact = contactList.getContactAtIndex(i);
+            if (duplicateField(addedContact.getName(), currentContact.getName())) {
+                duplicatedIndex.add(i);
+                continue;
+            }
+            if (addedContact.getGithub() != null && currentContact.getGithub() != null) {
+                if (duplicateField(addedContact.getGithub(), currentContact.getGithub())) {
+                    duplicatedIndex.add(i);
+                    continue;
+                }
+            }
+            if (addedContact.getEmail() != null && currentContact.getEmail() != null) {
+                if (duplicateField(addedContact.getEmail(), currentContact.getEmail())) {
+                    duplicatedIndex.add(i);
+                    continue;
+                }
+            }
+            if (addedContact.getTelegram() != null && currentContact.getTelegram() != null) {
+                if (duplicateField(addedContact.getTelegram(), currentContact.getTelegram())) {
+                    duplicatedIndex.add(i);
+                    continue;
+                }
+            }
+            if (addedContact.getLinkedin() != null && currentContact.getLinkedin() != null) {
+                if (duplicateField(addedContact.getLinkedin(), currentContact.getLinkedin())) {
+                    duplicatedIndex.add(i);
+                    continue;
+                }
+            }
+            if (addedContact.getTwitter() != null && currentContact.getTwitter() != null) {
+                if (duplicateField(addedContact.getTwitter(), currentContact.getTwitter())) {
+                    duplicatedIndex.add(i);
+                }
+            }
+        }
+        if (!duplicatedIndex.isEmpty()) {
+            TextUi.confirmAddDuplicateMessage(duplicatedIndex, contactList);
+            String userAddConfirmation = UserInputTextUi.getUserConfirmation();
+            return userAddConfirmation.equalsIgnoreCase("n");
+        }
+        return false;
+    }
     }
 }

--- a/src/main/java/seedu/command/AddContactCommand.java
+++ b/src/main/java/seedu/command/AddContactCommand.java
@@ -1,12 +1,16 @@
 package seedu.command;
 
 import seedu.contact.Contact;
+import seedu.contact.ContactComparator;
 import seedu.contact.ContactList;
 import seedu.contact.DetailType;
+import seedu.exception.InvalidFlagException;
+import seedu.ui.ExceptionTextUi;
 import seedu.ui.TextUi;
 import seedu.ui.UserInputTextUi;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 public class AddContactCommand extends Command {
     private final String name;
@@ -15,6 +19,13 @@ public class AddContactCommand extends Command {
     private final String telegram;
     private final String twitter;
     private final String email;
+    public static final int NUMBER_OF_FIELDS = 6;
+    public static final int NAME_INDEX = 0;
+    public static final int GITHUB_INDEX = 1;
+    public static final int LINKEDIN_INDEX = 2;
+    public static final int TELEGRAM_INDEX = 3;
+    public static final int TWITTER_INDEX = 4;
+    public static final int EMAIL_INDEX = 5;
 
     public String getLinkedin() {
         return linkedin;
@@ -50,55 +61,35 @@ public class AddContactCommand extends Command {
     }
 
     public void execute() {
-        Contact addedContact = new Contact(name, github, linkedin, telegram, twitter, email);
-        if (duplicateCatcher(addedContact, contactList)) {
-            TextUi.ignoreAddContact();
-        } else {
-            contactList.addContact(addedContact);
-            TextUi.addContactMessage(addedContact, contactList.getListSize());
+        try {
+            Contact addedContact = new Contact(name, github, linkedin, telegram, twitter, email);
+            if (hasDuplicates(addedContact, contactList)) {
+                TextUi.ignoreContact("add");
+            } else {
+                contactList.addContact(addedContact);
+                TextUi.addContactMessage(addedContact, contactList.getListSize());
+            }
+        } catch (InvalidFlagException e) {
+            ExceptionTextUi.invalidIndexMessage();
         }
     }
 
-    public Boolean duplicateCatcher(Contact addedContact, ContactList contactList) {
+    private Boolean hasDuplicates(Contact addedContact, ContactList contactList) throws InvalidFlagException {
         ArrayList<Integer> duplicatedIndex = new ArrayList<>();
+        String[] addedContactDetails = extractContactDetails(addedContact);
         for (int i = 0; i < contactList.getListSize(); i++) {
-            Contact currentContact = contactList.getContactAtIndex(i);
-            if (duplicateField(addedContact.getName(), currentContact.getName())) {
-                duplicatedIndex.add(i);
-                continue;
-            }
-            if (addedContact.getGithub() != null && currentContact.getGithub() != null) {
-                if (duplicateField(addedContact.getGithub(), currentContact.getGithub())) {
-                    duplicatedIndex.add(i);
-                    continue;
-                }
-            }
-            if (addedContact.getEmail() != null && currentContact.getEmail() != null) {
-                if (duplicateField(addedContact.getEmail(), currentContact.getEmail())) {
-                    duplicatedIndex.add(i);
-                    continue;
-                }
-            }
-            if (addedContact.getTelegram() != null && currentContact.getTelegram() != null) {
-                if (duplicateField(addedContact.getTelegram(), currentContact.getTelegram())) {
-                    duplicatedIndex.add(i);
-                    continue;
-                }
-            }
-            if (addedContact.getLinkedin() != null && currentContact.getLinkedin() != null) {
-                if (duplicateField(addedContact.getLinkedin(), currentContact.getLinkedin())) {
-                    duplicatedIndex.add(i);
-                    continue;
-                }
-            }
-            if (addedContact.getTwitter() != null && currentContact.getTwitter() != null) {
-                if (duplicateField(addedContact.getTwitter(), currentContact.getTwitter())) {
-                    duplicatedIndex.add(i);
+            String[] currentContactDetails = extractContactDetails(contactList.getContactAtIndex(i));
+            for (int j = 0; j < NUMBER_OF_FIELDS; j++) {
+                if (addedContactDetails[j] != null && currentContactDetails[j] != null) {
+                    if (hasDuplicateField(addedContactDetails[j], currentContactDetails[j])) {
+                        duplicatedIndex.add(i);
+                        break;
+                    }
                 }
             }
         }
         if (!duplicatedIndex.isEmpty()) {
-            TextUi.confirmAddDuplicateMessage(duplicatedIndex, contactList);
+            TextUi.confirmDuplicateMessage(duplicatedIndex, contactList, "add");
             String userAddConfirmation = UserInputTextUi.getUserConfirmation();
             return userAddConfirmation.equalsIgnoreCase("n");
         }

--- a/src/main/java/seedu/command/AddContactCommand.java
+++ b/src/main/java/seedu/command/AddContactCommand.java
@@ -96,11 +96,41 @@ public class AddContactCommand extends Command {
         return false;
     }
 
-    public Boolean duplicateField(String input, String saved) {
+    private String[] extractContactDetails(Contact contact) throws InvalidFlagException {
+        String[] contactDetails = new String[NUMBER_OF_FIELDS];
+        for (int i = 0; i < NUMBER_OF_FIELDS; i++) {
+            switch (i) {
+            case NAME_INDEX:
+                contactDetails[NAME_INDEX] = contact.getName();
+                break;
+            case GITHUB_INDEX:
+                contactDetails[GITHUB_INDEX] = contact.getGithub();
+                break;
+            case LINKEDIN_INDEX:
+                contactDetails[LINKEDIN_INDEX] = contact.getLinkedin();
+                break;
+            case TELEGRAM_INDEX:
+                contactDetails[TELEGRAM_INDEX] = contact.getTelegram();
+                break;
+            case TWITTER_INDEX:
+                contactDetails[TWITTER_INDEX] = contact.getTwitter();
+                break;
+            case EMAIL_INDEX:
+                contactDetails[EMAIL_INDEX] = contact.getEmail();
+                break;
+            default:
+                assert false;
+                throw new InvalidFlagException();
+            }
+        }
+        return contactDetails;
+    }
+
+    private Boolean hasDuplicateField(String input, String saved) {
         return stringCleaner(saved).equals(stringCleaner(input));
     }
 
-    public String stringCleaner(String input) {
+    private String stringCleaner(String input) {
         return input.replace(" ", "").toLowerCase();
     }
 }

--- a/src/main/java/seedu/command/EditContactCommand.java
+++ b/src/main/java/seedu/command/EditContactCommand.java
@@ -102,4 +102,9 @@ public class EditContactCommand extends Command {
         return stringCleaner(saved).equals(stringCleaner(input));
     }
 
+    public String stringCleaner(String input) {
+        return input.replace(" ", "").toLowerCase();
+    }
+
+
 }

--- a/src/main/java/seedu/command/EditContactCommand.java
+++ b/src/main/java/seedu/command/EditContactCommand.java
@@ -88,4 +88,14 @@ public class EditContactCommand extends Command {
         return false;
     }
 
+    public Contact duplicateContact(Contact contact) {
+        String name = contact.getName();
+        String github = contact.getGithub();
+        String linkedin = contact.getLinkedin();
+        String telegram = contact.getTelegram();
+        String twitter = contact.getTwitter();
+        String email = contact.getEmail();
+        return new Contact(name, github, linkedin, telegram, twitter, email);
+    }
+
 }

--- a/src/main/java/seedu/command/EditContactCommand.java
+++ b/src/main/java/seedu/command/EditContactCommand.java
@@ -139,4 +139,34 @@ public class EditContactCommand extends Command {
         }
         return tempContact;
     }
+
+    private String[] extractContactDetails(Contact contact) throws InvalidFlagException {
+        String[] contactDetails = new String[NUMBER_OF_FIELDS];
+        for (int i = 0; i < NUMBER_OF_FIELDS; i++) {
+            switch (i) {
+            case NAME_INDEX:
+                contactDetails[NAME_INDEX] = contact.getName();
+                break;
+            case GITHUB_INDEX:
+                contactDetails[GITHUB_INDEX] = contact.getGithub();
+                break;
+            case LINKEDIN_INDEX:
+                contactDetails[LINKEDIN_INDEX] = contact.getLinkedin();
+                break;
+            case TELEGRAM_INDEX:
+                contactDetails[TELEGRAM_INDEX] = contact.getTelegram();
+                break;
+            case TWITTER_INDEX:
+                contactDetails[TWITTER_INDEX] = contact.getTwitter();
+                break;
+            case EMAIL_INDEX:
+                contactDetails[EMAIL_INDEX] = contact.getEmail();
+                break;
+            default:
+                assert false;
+                throw new InvalidFlagException();
+            }
+        }
+        return contactDetails;
+    }
 }

--- a/src/main/java/seedu/command/EditContactCommand.java
+++ b/src/main/java/seedu/command/EditContactCommand.java
@@ -16,6 +16,7 @@ public class EditContactCommand extends Command {
     public static final int TELEGRAM_INDEX = 3;
     public static final int TWITTER_INDEX = 4;
     public static final int EMAIL_INDEX = 5;
+    public static final int NUMBER_OF_FIELDS = 6;
     String[] contactDetails;
     int contactIndex;
 
@@ -28,8 +29,8 @@ public class EditContactCommand extends Command {
         try {
             Contact preEditContact = duplicateContact(contactList.getContactAtIndex(contactIndex));
             Contact postEditContact = editTempContact(contactDetails,preEditContact);
-            if (duplicateCatcher(postEditContact, contactList, contactIndex)) {
-                TextUi.ignoreEditContact();
+            if (hasDuplicates(postEditContact, contactList, contactIndex)) {
+                TextUi.ignoreContact("edit");
             } else {
                 contactList.editContact(contactDetails, contactIndex);
                 TextUi.editContactMessage(postEditContact);
@@ -98,16 +99,16 @@ public class EditContactCommand extends Command {
         return new Contact(name, github, linkedin, telegram, twitter, email);
     }
 
-    public Boolean duplicateField(String input, String saved) {
+    private Boolean hasDuplicateField(String input, String saved) {
         return stringCleaner(saved).equals(stringCleaner(input));
     }
 
-    public String stringCleaner(String input) {
+    private String stringCleaner(String input) {
         return input.replace(" ", "").toLowerCase();
     }
 
 
-    public Contact editTempContact(String[] contactDetails, Contact preEditContact) throws InvalidFlagException {
+    private Contact editTempContact(String[] contactDetails, Contact preEditContact) throws InvalidFlagException {
         Contact tempContact = duplicateContact(preEditContact);
         for (int i = 0; i < contactDetails.length; i++) {
             if (contactDetails[i] != null) {
@@ -131,7 +132,6 @@ public class EditContactCommand extends Command {
                     tempContact.setEmail(contactDetails[i]);
                     break;
                 default:
-                    //control should never reach here
                     assert false;
                     throw new InvalidFlagException();
                 }

--- a/src/main/java/seedu/command/EditContactCommand.java
+++ b/src/main/java/seedu/command/EditContactCommand.java
@@ -98,4 +98,8 @@ public class EditContactCommand extends Command {
         return new Contact(name, github, linkedin, telegram, twitter, email);
     }
 
+    public Boolean duplicateField(String input, String saved) {
+        return stringCleaner(saved).equals(stringCleaner(input));
+    }
+
 }

--- a/src/main/java/seedu/command/EditContactCommand.java
+++ b/src/main/java/seedu/command/EditContactCommand.java
@@ -38,4 +38,54 @@ public class EditContactCommand extends Command {
             ExceptionTextUi.invalidIndexMessage();
         }
     }
+
+    public Boolean duplicateCatcher(Contact postEditContact, ContactList contactList, int contactIndex) {
+        ArrayList<Integer> duplicatedIndex = new ArrayList<>();
+        for (int i = 0; i < contactList.getListSize(); i++) {
+            if (i == contactIndex) {
+                continue;
+            }
+            Contact currentContact = contactList.getContactAtIndex(i);
+            if (duplicateField(postEditContact.getName(), currentContact.getName())) {
+                duplicatedIndex.add(i);
+                continue;
+            }
+            if (postEditContact.getGithub() != null && currentContact.getGithub() != null) {
+                if (duplicateField(postEditContact.getGithub(), currentContact.getGithub())) {
+                    duplicatedIndex.add(i);
+                    continue;
+                }
+            }
+            if (postEditContact.getEmail() != null && currentContact.getEmail() != null) {
+                if (duplicateField(postEditContact.getEmail(), currentContact.getEmail())) {
+                    duplicatedIndex.add(i);
+                    continue;
+                }
+            }
+            if (postEditContact.getTelegram() != null && currentContact.getTelegram() != null) {
+                if (duplicateField(postEditContact.getTelegram(), currentContact.getTelegram())) {
+                    duplicatedIndex.add(i);
+                    continue;
+                }
+            }
+            if (postEditContact.getLinkedin() != null && currentContact.getLinkedin() != null) {
+                if (duplicateField(postEditContact.getLinkedin(), currentContact.getLinkedin())) {
+                    duplicatedIndex.add(i);
+                    continue;
+                }
+            }
+            if (postEditContact.getTwitter() != null && currentContact.getTwitter() != null) {
+                if (duplicateField(postEditContact.getTwitter(), currentContact.getTwitter())) {
+                    duplicatedIndex.add(i);
+                }
+            }
+        }
+        if (!duplicatedIndex.isEmpty()) {
+            TextUi.confirmEditDuplicateMessage(duplicatedIndex, contactList);
+            String userEditConfirmation = UserInputTextUi.getUserConfirmation();
+            return userEditConfirmation.equalsIgnoreCase("n");
+        }
+        return false;
+    }
+
 }

--- a/src/main/java/seedu/command/EditContactCommand.java
+++ b/src/main/java/seedu/command/EditContactCommand.java
@@ -1,10 +1,21 @@
 package seedu.command;
 
+import seedu.contact.Contact;
+import seedu.contact.ContactList;
 import seedu.exception.InvalidFlagException;
 import seedu.ui.TextUi;
 import seedu.ui.ExceptionTextUi;
+import seedu.ui.UserInputTextUi;
+
+import java.util.ArrayList;
 
 public class EditContactCommand extends Command {
+    public static final int NAME_INDEX = 0;
+    public static final int GITHUB_INDEX = 1;
+    public static final int LINKEDIN_INDEX = 2;
+    public static final int TELEGRAM_INDEX = 3;
+    public static final int TWITTER_INDEX = 4;
+    public static final int EMAIL_INDEX = 5;
     String[] contactDetails;
     int contactIndex;
 
@@ -15,8 +26,14 @@ public class EditContactCommand extends Command {
 
     public void execute() {
         try {
-            contactList.editContact(contactDetails, contactIndex);
-            TextUi.editContactMessage(contactList.getContactAtIndex(contactIndex));
+            Contact preEditContact = duplicateContact(contactList.getContactAtIndex(contactIndex));
+            Contact postEditContact = editTempContact(contactDetails,preEditContact);
+            if (duplicateCatcher(postEditContact, contactList, contactIndex)) {
+                TextUi.ignoreEditContact();
+            } else {
+                contactList.editContact(contactDetails, contactIndex);
+                TextUi.editContactMessage(postEditContact);
+            }
         } catch (IndexOutOfBoundsException | InvalidFlagException e) {
             ExceptionTextUi.invalidIndexMessage();
         }

--- a/src/main/java/seedu/command/EditContactCommand.java
+++ b/src/main/java/seedu/command/EditContactCommand.java
@@ -107,4 +107,36 @@ public class EditContactCommand extends Command {
     }
 
 
+    public Contact editTempContact(String[] contactDetails, Contact preEditContact) throws InvalidFlagException {
+        Contact tempContact = duplicateContact(preEditContact);
+        for (int i = 0; i < contactDetails.length; i++) {
+            if (contactDetails[i] != null) {
+                switch (i) {
+                case NAME_INDEX:
+                    tempContact.setName(contactDetails[i]);
+                    break;
+                case GITHUB_INDEX:
+                    tempContact.setGithub(contactDetails[i]);
+                    break;
+                case LINKEDIN_INDEX:
+                    tempContact.setLinkedin(contactDetails[i]);
+                    break;
+                case TELEGRAM_INDEX:
+                    tempContact.setTelegram(contactDetails[i]);
+                    break;
+                case TWITTER_INDEX:
+                    tempContact.setTwitter(contactDetails[i]);
+                    break;
+                case EMAIL_INDEX:
+                    tempContact.setEmail(contactDetails[i]);
+                    break;
+                default:
+                    //control should never reach here
+                    assert false;
+                    throw new InvalidFlagException();
+                }
+            }
+        }
+        return tempContact;
+    }
 }

--- a/src/main/java/seedu/command/EditContactCommand.java
+++ b/src/main/java/seedu/command/EditContactCommand.java
@@ -40,56 +40,34 @@ public class EditContactCommand extends Command {
         }
     }
 
-    public Boolean duplicateCatcher(Contact postEditContact, ContactList contactList, int contactIndex) {
+    private Boolean hasDuplicates(Contact postEditContact, ContactList contactList, int contactIndex)
+            throws InvalidFlagException {
         ArrayList<Integer> duplicatedIndex = new ArrayList<>();
+        String[] postEditContactDetails = extractContactDetails(postEditContact);
         for (int i = 0; i < contactList.getListSize(); i++) {
             if (i == contactIndex) {
                 continue;
             }
-            Contact currentContact = contactList.getContactAtIndex(i);
-            if (duplicateField(postEditContact.getName(), currentContact.getName())) {
-                duplicatedIndex.add(i);
-                continue;
-            }
-            if (postEditContact.getGithub() != null && currentContact.getGithub() != null) {
-                if (duplicateField(postEditContact.getGithub(), currentContact.getGithub())) {
-                    duplicatedIndex.add(i);
-                    continue;
+            String[] currentContactDetails = extractContactDetails(contactList.getContactAtIndex(i));
+            for (int j = 0; j < NUMBER_OF_FIELDS; j++) {
+                if (postEditContactDetails[j] != null && currentContactDetails[j] != null) {
+                    if (hasDuplicateField(postEditContactDetails[j], currentContactDetails[j])) {
+                        duplicatedIndex.add(i);
+                        break;
+                    }
                 }
             }
-            if (postEditContact.getEmail() != null && currentContact.getEmail() != null) {
-                if (duplicateField(postEditContact.getEmail(), currentContact.getEmail())) {
-                    duplicatedIndex.add(i);
-                    continue;
-                }
-            }
-            if (postEditContact.getTelegram() != null && currentContact.getTelegram() != null) {
-                if (duplicateField(postEditContact.getTelegram(), currentContact.getTelegram())) {
-                    duplicatedIndex.add(i);
-                    continue;
-                }
-            }
-            if (postEditContact.getLinkedin() != null && currentContact.getLinkedin() != null) {
-                if (duplicateField(postEditContact.getLinkedin(), currentContact.getLinkedin())) {
-                    duplicatedIndex.add(i);
-                    continue;
-                }
-            }
-            if (postEditContact.getTwitter() != null && currentContact.getTwitter() != null) {
-                if (duplicateField(postEditContact.getTwitter(), currentContact.getTwitter())) {
-                    duplicatedIndex.add(i);
-                }
-            }
+
         }
         if (!duplicatedIndex.isEmpty()) {
-            TextUi.confirmEditDuplicateMessage(duplicatedIndex, contactList);
+            TextUi.confirmDuplicateMessage(duplicatedIndex, contactList, "edit");
             String userEditConfirmation = UserInputTextUi.getUserConfirmation();
             return userEditConfirmation.equalsIgnoreCase("n");
         }
         return false;
     }
 
-    public Contact duplicateContact(Contact contact) {
+    private Contact duplicateContact(Contact contact) {
         String name = contact.getName();
         String github = contact.getGithub();
         String linkedin = contact.getLinkedin();

--- a/src/main/java/seedu/ui/TextUi.java
+++ b/src/main/java/seedu/ui/TextUi.java
@@ -249,4 +249,10 @@ public abstract class TextUi {
         }
     }
 
+    public static void duplicatedContactsMessage(Contact viewingContact, int index) {
+        String viewName = ViewMessageFormatterUi.viewNameFormatter(viewingContact);
+        String message = index + ". " + viewName + formatContactFields(viewingContact);
+        System.out.println(message + "\n");
+    }
+
 }

--- a/src/main/java/seedu/ui/TextUi.java
+++ b/src/main/java/seedu/ui/TextUi.java
@@ -216,17 +216,35 @@ public abstract class TextUi {
     public static void confirmAddDuplicateMessage(ArrayList<Integer> duplicatedIndex, ContactList contactList) {
         if (duplicatedIndex.size() == 1) {
             Contact currentContact = contactList.getContactAtIndex(duplicatedIndex.get(0));
-            String message = "One of your saved contacts has a similar field:\n"
+            String message = "One of your saved contacts has a duplicate field:\n"
                     + "\n" + duplicatedIndex.get(0) + ". " + currentContact.getName()
                     + formatContactFields(currentContact) + "\n\nDo you still want to add the contact?  (y/n)\n";
             printDoubleLineMessage(message);
         } else {
             System.out.println(LINE);
-            System.out.println("These contacts are duplicates:\n");
+            System.out.println("These contacts have duplicate fields:\n");
             for (Integer index : duplicatedIndex) {
                 duplicatedContactsMessage(contactList.getContactAtIndex(index), index);
             }
             System.out.println("Do you still want to add the contact?  (y/n)\n");
+            System.out.println(LINE);
+        }
+    }
+
+    public static void confirmEditDuplicateMessage(ArrayList<Integer> duplicatedIndex, ContactList contactList) {
+        if (duplicatedIndex.size() == 1) {
+            Contact currentContact = contactList.getContactAtIndex(duplicatedIndex.get(0));
+            String message = "One of your saved contacts has a duplicate field:\n"
+                    + "\n" + duplicatedIndex.get(0) + ". " + currentContact.getName()
+                    + formatContactFields(currentContact) + "\n\nDo you still want to edit the contact?  (y/n)\n";
+            printDoubleLineMessage(message);
+        } else {
+            System.out.println(LINE);
+            System.out.println("These contacts have duplicate fields:\n");
+            for (Integer index : duplicatedIndex) {
+                duplicatedContactsMessage(contactList.getContactAtIndex(index), index);
+            }
+            System.out.println("Do you still want to edit the contact?  (y/n)\n");
             System.out.println(LINE);
         }
     }

--- a/src/main/java/seedu/ui/TextUi.java
+++ b/src/main/java/seedu/ui/TextUi.java
@@ -255,4 +255,9 @@ public abstract class TextUi {
         System.out.println(message + "\n");
     }
 
+    public static void ignoreAddContact() {
+        String message = "Contact was not added.";
+        printDoubleLineMessage(message);
+    }
+
 }

--- a/src/main/java/seedu/ui/TextUi.java
+++ b/src/main/java/seedu/ui/TextUi.java
@@ -260,4 +260,9 @@ public abstract class TextUi {
         printDoubleLineMessage(message);
     }
 
+    public static void ignoreEditContact() {
+        String message = "Contact was not edited.";
+        printDoubleLineMessage(message);
+    }
+
 }

--- a/src/main/java/seedu/ui/TextUi.java
+++ b/src/main/java/seedu/ui/TextUi.java
@@ -213,12 +213,20 @@ public abstract class TextUi {
         printDoubleLineMessage(message);
     }
 
-    public static void confirmAddDuplicateMessage(ArrayList<Integer> duplicatedIndex, ContactList contactList) {
+    public static void confirmDuplicateMessage(ArrayList<Integer> duplicatedIndex,
+                                               ContactList contactList, String type) {
         if (duplicatedIndex.size() == 1) {
             Contact currentContact = contactList.getContactAtIndex(duplicatedIndex.get(0));
-            String message = "One of your saved contacts has a duplicate field:\n"
-                    + "\n" + duplicatedIndex.get(0) + ". " + currentContact.getName()
-                    + formatContactFields(currentContact) + "\n\nDo you still want to add the contact?  (y/n)\n";
+            String message;
+            if (type.equals("add")) {
+                message = "One of your saved contacts has a duplicate field:\n"
+                        + "\n" + duplicatedIndex.get(0) + ". " + currentContact.getName()
+                        + formatContactFields(currentContact) + "\n\nDo you still want to add the contact?  (y/n)\n";
+            } else {
+                message = "One of your saved contacts has a duplicate field:\n"
+                        + "\n" + duplicatedIndex.get(0) + ". " + currentContact.getName()
+                        + formatContactFields(currentContact) + "\n\nDo you still want to edit the contact?  (y/n)\n";
+            }
             printDoubleLineMessage(message);
         } else {
             System.out.println(LINE);
@@ -226,25 +234,11 @@ public abstract class TextUi {
             for (Integer index : duplicatedIndex) {
                 duplicatedContactsMessage(contactList.getContactAtIndex(index), index);
             }
-            System.out.println("Do you still want to add the contact?  (y/n)\n");
-            System.out.println(LINE);
-        }
-    }
-
-    public static void confirmEditDuplicateMessage(ArrayList<Integer> duplicatedIndex, ContactList contactList) {
-        if (duplicatedIndex.size() == 1) {
-            Contact currentContact = contactList.getContactAtIndex(duplicatedIndex.get(0));
-            String message = "One of your saved contacts has a duplicate field:\n"
-                    + "\n" + duplicatedIndex.get(0) + ". " + currentContact.getName()
-                    + formatContactFields(currentContact) + "\n\nDo you still want to edit the contact?  (y/n)\n";
-            printDoubleLineMessage(message);
-        } else {
-            System.out.println(LINE);
-            System.out.println("These contacts have duplicate fields:\n");
-            for (Integer index : duplicatedIndex) {
-                duplicatedContactsMessage(contactList.getContactAtIndex(index), index);
+            if (type.equals("add")) {
+                System.out.println("Do you still want to add the contact?  (y/n)\n");
+            } else {
+                System.out.println("Do you still want to edit the contact?  (y/n)\n");
             }
-            System.out.println("Do you still want to edit the contact?  (y/n)\n");
             System.out.println(LINE);
         }
     }

--- a/src/main/java/seedu/ui/TextUi.java
+++ b/src/main/java/seedu/ui/TextUi.java
@@ -1,7 +1,9 @@
 package seedu.ui;
 
 import seedu.contact.Contact;
+import seedu.contact.ContactList;
 
+import java.util.ArrayList;
 import java.util.Scanner;
 
 public abstract class TextUi {
@@ -209,6 +211,24 @@ public abstract class TextUi {
                 + "help: Displays application usage instructions.\n"
                 + " Example: help";
         printDoubleLineMessage(message);
+    }
+
+    public static void confirmAddDuplicateMessage(ArrayList<Integer> duplicatedIndex, ContactList contactList) {
+        if (duplicatedIndex.size() == 1) {
+            Contact currentContact = contactList.getContactAtIndex(duplicatedIndex.get(0));
+            String message = "One of your saved contacts has a similar field:\n"
+                    + "\n" + duplicatedIndex.get(0) + ". " + currentContact.getName()
+                    + formatContactFields(currentContact) + "\n\nDo you still want to add the contact?  (y/n)\n";
+            printDoubleLineMessage(message);
+        } else {
+            System.out.println(LINE);
+            System.out.println("These contacts are duplicates:\n");
+            for (Integer index : duplicatedIndex) {
+                duplicatedContactsMessage(contactList.getContactAtIndex(index), index);
+            }
+            System.out.println("Do you still want to add the contact?  (y/n)\n");
+            System.out.println(LINE);
+        }
     }
 
 }

--- a/src/main/java/seedu/ui/TextUi.java
+++ b/src/main/java/seedu/ui/TextUi.java
@@ -249,13 +249,13 @@ public abstract class TextUi {
         System.out.println(message + "\n");
     }
 
-    public static void ignoreAddContact() {
-        String message = "Contact was not added.";
-        printDoubleLineMessage(message);
-    }
-
-    public static void ignoreEditContact() {
-        String message = "Contact was not edited.";
+    public static void ignoreContact(String type) {
+        String message;
+        if (type.equals("add")) {
+            message = "Contact was not added.";
+        } else {
+            message = "Contact was not edited.";
+        }
         printDoubleLineMessage(message);
     }
 

--- a/text-ui-test/ACTUAL.TXT
+++ b/text-ui-test/ACTUAL.TXT
@@ -151,6 +151,16 @@ You now have 4 contact(s).
 ____________________________________________________________
 
 ____________________________________________________________
+One of your saved contacts has a duplicate field:
+
+3. ng andre
+Github:   github.com/ng-andre
+
+Do you still want to add the contact?  (y/n)
+
+____________________________________________________________
+
+____________________________________________________________
 ConTech has added the specified contact:
 Name:     andre
 Github:   github.com/ng-andre
@@ -414,6 +424,16 @@ Due to the storage nature of ConTech, we will remove
 commas (","), and attempt to parse it as:
 add -n lezong mun -g    lezaimun
 ____________________________________________________________
+One of your saved contacts has a duplicate field:
+
+2. lezongmun
+Github:   github.com/lezong
+
+Do you still want to add the contact?  (y/n)
+
+____________________________________________________________
+
+____________________________________________________________
 ConTech has added the specified contact:
 Name:     lezong mun
 Github:   github.com/lezaimun
@@ -440,6 +460,16 @@ You now have 8 contact(s).
 ____________________________________________________________
 
 ____________________________________________________________
+One of your saved contacts has a duplicate field:
+
+4. lezongmun
+Github:   github.com/lezong
+
+Do you still want to edit the contact?  (y/n)
+
+____________________________________________________________
+
+____________________________________________________________
 ConTech has edited the specified contact:
 Name:     lezong mun
 Github:   github.com/new-git
@@ -454,19 +484,26 @@ Rules for Twitter username :
 ____________________________________________________________
 
 ____________________________________________________________
+ConTech is unable to understand your request.
+Please try again with a valid command.
+____________________________________________________________
+
+____________________________________________________________
+One of your saved contacts has a duplicate field:
+
+0. asjoda sadfsd
+Telegram: t.me/_123adad
+
+Do you still want to add the contact?  (y/n)
+
+____________________________________________________________
+
+____________________________________________________________
 ConTech has added the specified contact:
 Name:     asjoda sadfsd
 Twitter:  twitter.com/123_adad
 
 You now have 9 contact(s).
-____________________________________________________________
-
-____________________________________________________________
-The email id is not correctly formatted,
-Rules for email id :
-    * Lowercase letters only
-    * Numbers, underscore, hyphen and dot allowed
-    * @ cannot be at the start or end
 ____________________________________________________________
 
 ____________________________________________________________

--- a/text-ui-test/EXPECTED-UNIX.TXT
+++ b/text-ui-test/EXPECTED-UNIX.TXT
@@ -151,6 +151,16 @@ You now have 4 contact(s).
 ____________________________________________________________
 
 ____________________________________________________________
+One of your saved contacts has a duplicate field:
+
+3. ng andre
+Github:   github.com/ng-andre
+
+Do you still want to add the contact?  (y/n)
+
+____________________________________________________________
+
+____________________________________________________________
 ConTech has added the specified contact:
 Name:     andre
 Github:   github.com/ng-andre
@@ -414,6 +424,16 @@ Due to the storage nature of ConTech, we will remove
 commas (","), and attempt to parse it as:
 add -n lezong mun -g    lezaimun
 ____________________________________________________________
+One of your saved contacts has a duplicate field:
+
+2. lezongmun
+Github:   github.com/lezong
+
+Do you still want to add the contact?  (y/n)
+
+____________________________________________________________
+
+____________________________________________________________
 ConTech has added the specified contact:
 Name:     lezong mun
 Github:   github.com/lezaimun
@@ -440,6 +460,16 @@ You now have 8 contact(s).
 ____________________________________________________________
 
 ____________________________________________________________
+One of your saved contacts has a duplicate field:
+
+4. lezongmun
+Github:   github.com/lezong
+
+Do you still want to edit the contact?  (y/n)
+
+____________________________________________________________
+
+____________________________________________________________
 ConTech has edited the specified contact:
 Name:     lezong mun
 Github:   github.com/new-git
@@ -454,19 +484,26 @@ Rules for Twitter username :
 ____________________________________________________________
 
 ____________________________________________________________
+ConTech is unable to understand your request.
+Please try again with a valid command.
+____________________________________________________________
+
+____________________________________________________________
+One of your saved contacts has a duplicate field:
+
+0. asjoda sadfsd
+Telegram: t.me/_123adad
+
+Do you still want to add the contact?  (y/n)
+
+____________________________________________________________
+
+____________________________________________________________
 ConTech has added the specified contact:
 Name:     asjoda sadfsd
 Twitter:  twitter.com/123_adad
 
 You now have 9 contact(s).
-____________________________________________________________
-
-____________________________________________________________
-The email id is not correctly formatted,
-Rules for email id :
-    * Lowercase letters only
-    * Numbers, underscore, hyphen and dot allowed
-    * @ cannot be at the start or end
 ____________________________________________________________
 
 ____________________________________________________________

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -151,6 +151,16 @@ You now have 4 contact(s).
 ____________________________________________________________
 
 ____________________________________________________________
+One of your saved contacts has a duplicate field:
+
+3. ng andre
+Github:   github.com/ng-andre
+
+Do you still want to add the contact?  (y/n)
+
+____________________________________________________________
+
+____________________________________________________________
 ConTech has added the specified contact:
 Name:     andre
 Github:   github.com/ng-andre
@@ -414,6 +424,16 @@ Due to the storage nature of ConTech, we will remove
 commas (","), and attempt to parse it as:
 add -n lezong mun -g    lezaimun
 ____________________________________________________________
+One of your saved contacts has a duplicate field:
+
+2. lezongmun
+Github:   github.com/lezong
+
+Do you still want to add the contact?  (y/n)
+
+____________________________________________________________
+
+____________________________________________________________
 ConTech has added the specified contact:
 Name:     lezong mun
 Github:   github.com/lezaimun
@@ -440,6 +460,16 @@ You now have 8 contact(s).
 ____________________________________________________________
 
 ____________________________________________________________
+One of your saved contacts has a duplicate field:
+
+4. lezongmun
+Github:   github.com/lezong
+
+Do you still want to edit the contact?  (y/n)
+
+____________________________________________________________
+
+____________________________________________________________
 ConTech has edited the specified contact:
 Name:     lezong mun
 Github:   github.com/new-git
@@ -454,19 +484,26 @@ Rules for Twitter username :
 ____________________________________________________________
 
 ____________________________________________________________
+ConTech is unable to understand your request.
+Please try again with a valid command.
+____________________________________________________________
+
+____________________________________________________________
+One of your saved contacts has a duplicate field:
+
+0. asjoda sadfsd
+Telegram: t.me/_123adad
+
+Do you still want to add the contact?  (y/n)
+
+____________________________________________________________
+
+____________________________________________________________
 ConTech has added the specified contact:
 Name:     asjoda sadfsd
 Twitter:  twitter.com/123_adad
 
 You now have 9 contact(s).
-____________________________________________________________
-
-____________________________________________________________
-The email id is not correctly formatted,
-Rules for email id :
-    * Lowercase letters only
-    * Numbers, underscore, hyphen and dot allowed
-    * @ cannot be at the start or end
 ____________________________________________________________
 
 ____________________________________________________________

--- a/text-ui-test/input.txt
+++ b/text-ui-test/input.txt
@@ -19,6 +19,7 @@ add -n mayank -g mayankp123
 rm 9909
 add -n bory -g marcus
 add       -n   andre   -g ng-andre
+y
 list
 view 1
 add -n bory -g
@@ -53,11 +54,14 @@ add -n asjoda sadfsd -te _123adad
 view 0
    add  -n   -g
       add -n le,zong, mun -g    lezaimun
+      y
        add   -n null  -g legit
        add -n name -g null
        add   -n dev -g nullptr
     edit 3 -g new-git
+    y
     add -n asjoda sadfsd -tw _123  adad
+    y
     add -n asjoda sadfsd -tw 123_adad
 add -n name -l linkedin -g github -e lasdas@ -tw twitter -te telegram
 add -n asdasd -l kusdd__ -g adasdas -e .adadas@com


### PR DESCRIPTION
Fixes #65, Fixes #66, Fixes #67, Fixes #68 

New implementations in this PR:
- Add feature will now search through contact list for any duplicates to the contact that is being added
- Edit feature will now search through contact list for any duplicates to what the contact is being edited to
- If duplicates are found for either add or edit features, user will be asked to confirm whether to continue adding or editing the contact